### PR TITLE
feature: define relation tuple as core ReBAC primitive

### DIFF
--- a/core/src/main/java/io/github/chanwoo040531/springrebac/DefaultRelationTuple.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/DefaultRelationTuple.java
@@ -1,0 +1,8 @@
+package io.github.chanwoo040531.springrebac;
+
+public record DefaultRelationTuple(
+	ResourceRef resource,
+	Relation relation,
+	SubjectRef subject
+) implements RelationTuple {
+}

--- a/core/src/main/java/io/github/chanwoo040531/springrebac/Relation.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/Relation.java
@@ -1,0 +1,7 @@
+package io.github.chanwoo040531.springrebac;
+
+/**
+ * Named relation between a resource and subject.
+ */
+public record Relation(String name) {
+}

--- a/core/src/main/java/io/github/chanwoo040531/springrebac/RelationTuple.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/RelationTuple.java
@@ -1,4 +1,34 @@
 package io.github.chanwoo040531.springrebac;
 
-public interface RelationTuple {
+/**
+ * Relation tuple for ReBAC: resource (type + id), relation, subject (type + id).
+ */
+public record RelationTuple(
+        String resourceType,
+        String resourceId,
+        String relation,
+        String subjectType,
+        String subjectId
+) {
+    public RelationTuple {
+        if (isBlank(resourceType)) {
+            throw new IllegalArgumentException("resourceType is required");
+        }
+        if (isBlank(resourceId)) {
+            throw new IllegalArgumentException("resourceId is required");
+        }
+        if (isBlank(relation)) {
+            throw new IllegalArgumentException("relation is required");
+        }
+        if (isBlank(subjectType)) {
+            throw new IllegalArgumentException("subjectType is required");
+        }
+        if (isBlank(subjectId)) {
+            throw new IllegalArgumentException("subjectId is required");
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
 }

--- a/core/src/main/java/io/github/chanwoo040531/springrebac/RelationTuple.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/RelationTuple.java
@@ -1,34 +1,13 @@
 package io.github.chanwoo040531.springrebac;
 
 /**
- * Relation tuple for ReBAC: resource (type + id), relation, subject (type + id).
+ * Relation tuple for ReBAC: resource, relation, subject.
  */
-public record RelationTuple(
-        String resourceType,
-        String resourceId,
-        String relation,
-        String subjectType,
-        String subjectId
-) {
-    public RelationTuple {
-        if (isBlank(resourceType)) {
-            throw new IllegalArgumentException("resourceType is required");
-        }
-        if (isBlank(resourceId)) {
-            throw new IllegalArgumentException("resourceId is required");
-        }
-        if (isBlank(relation)) {
-            throw new IllegalArgumentException("relation is required");
-        }
-        if (isBlank(subjectType)) {
-            throw new IllegalArgumentException("subjectType is required");
-        }
-        if (isBlank(subjectId)) {
-            throw new IllegalArgumentException("subjectId is required");
-        }
-    }
+public interface RelationTuple {
 
-    private static boolean isBlank(String value) {
-        return value == null || value.isBlank();
-    }
+    ResourceRef resource();
+
+    Relation relation();
+
+    SubjectRef subject();
 }

--- a/core/src/main/java/io/github/chanwoo040531/springrebac/RelationTupleFactory.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/RelationTupleFactory.java
@@ -1,0 +1,35 @@
+package io.github.chanwoo040531.springrebac;
+
+/**
+ * Factory for creating validated relation tuples.
+ */
+public final class RelationTupleFactory {
+
+    private RelationTupleFactory() {
+    }
+
+    public static RelationTuple create(ResourceRef resource, Relation relation, SubjectRef subject) {
+        if (resource == null) {
+            throw new IllegalArgumentException("resource is required");
+        }
+        if (relation == null) {
+            throw new IllegalArgumentException("relation is required");
+        }
+        if (subject == null) {
+            throw new IllegalArgumentException("subject is required");
+        }
+        requireText(resource.type(), "resourceType");
+        requireText(resource.id(), "resourceId");
+        requireText(relation.name(), "relation");
+        requireText(subject.type(), "subjectType");
+        requireText(subject.id(), "subjectId");
+        return new DefaultRelationTuple(resource, relation, subject);
+    }
+
+    private static void requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+    }
+
+}

--- a/core/src/main/java/io/github/chanwoo040531/springrebac/ResourceRef.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/ResourceRef.java
@@ -1,0 +1,7 @@
+package io.github.chanwoo040531.springrebac;
+
+/**
+ * Reference to a resource by type and id.
+ */
+public record ResourceRef(String type, String id) {
+}

--- a/core/src/main/java/io/github/chanwoo040531/springrebac/SubjectRef.java
+++ b/core/src/main/java/io/github/chanwoo040531/springrebac/SubjectRef.java
@@ -1,0 +1,7 @@
+package io.github.chanwoo040531.springrebac;
+
+/**
+ * Reference to a subject by type and id.
+ */
+public record SubjectRef(String type, String id) {
+}


### PR DESCRIPTION
This PR introduces `RelationTuple` as the core primitive for modeling relationships in the ReBAC authorization model.

A relation tuple represents a single relationship between a resource and a subject:

(resourceType, resourceId, relation, subjectType, subjectId)

Why
- Enables graph-based authorization instead of role-centric rules
- Provides a minimal, explicit unit for expressing all access relationships

Scope
- Adds the RelationTuple domain type
- Enforces non-null / non-blank constraints
- Does not include permission evaluation or storage logic

This establishes the foundation for future ReBAC features such as expand rules and permission checks.